### PR TITLE
feat: Add motia-workbench configuration and update dependencies for RAG example.

### DIFF
--- a/examples/rag_example/.mermaid/parse-embed-rag.mmd
+++ b/examples/rag_example/.mermaid/parse-embed-rag.mmd
@@ -1,0 +1,14 @@
+flowchart TD
+    classDef apiStyle fill:#f96,stroke:#333,stroke-width:2px,color:#fff
+    classDef eventStyle fill:#69f,stroke:#333,stroke-width:2px,color:#fff
+    classDef cronStyle fill:#9c6,stroke:#333,stroke-width:2px,color:#fff
+    classDef noopStyle fill:#3f3a50,stroke:#333,stroke-width:2px,color:#fff
+    steps_chunk_step_py["⚡ Chunk & Save"]:::eventStyle
+    steps_embed_step_py["⚡ Embed & Save"]:::eventStyle
+    steps_index_step_py["⚡ Index & Save"]:::eventStyle
+    steps_parse_step_py["🌐 Parser API"]:::apiStyle
+    steps_rag_api_step_py["🌐 Rag API"]:::apiStyle
+    steps_chunk_step_py -->|chunk.complete| steps_embed_step_py
+    steps_chunk_step_py -->|chunk.complete| steps_index_step_py
+    steps_embed_step_py -->|embed.complete| steps_index_step_py
+    steps_parse_step_py -->|parse.complete| steps_chunk_step_py

--- a/examples/rag_example/motia-workbench.json
+++ b/examples/rag_example/motia-workbench.json
@@ -1,0 +1,24 @@
+{
+  "parse-embed-rag": {
+    "steps/chunk.step.py": {
+      "x": 90.5,
+      "y": 256
+    },
+    "steps/embed.step.py": {
+      "x": 229.59075630252102,
+      "y": 430.8168067226891
+    },
+    "steps/index.step.py": {
+      "x": 93.5,
+      "y": 608
+    },
+    "steps/parse.step.py": {
+      "x": 0,
+      "y": 0
+    },
+    "steps/rag_api.step.py": {
+      "x": 410,
+      "y": 0
+    }
+  }
+}

--- a/examples/rag_example/package.json
+++ b/examples/rag_example/package.json
@@ -10,13 +10,13 @@
     "motia"
   ],
   "dependencies": {
-    "motia": "^0.1.0-beta.5",
+    "motia": "^0.1.0-beta.15",
     "react": "^19.0.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@types/react": "^18.3.18",
+    "@types/react": "^19.0.12",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
   }
 }

--- a/examples/rag_example/steps/chunk.step.py
+++ b/examples/rag_example/steps/chunk.step.py
@@ -32,7 +32,7 @@ async def handler(req, ctx):
         ctx.logger.error(f"Error chunking parsed website data: {e}")
     
     await ctx.emit({
-        'type': 'chunk.complete',
+        'topic': 'chunk.complete',
         'data': {'message': 'chunking completed'}
     })
     return

--- a/examples/rag_example/steps/embed.step.py
+++ b/examples/rag_example/steps/embed.step.py
@@ -20,7 +20,7 @@ async def handler(req, ctx):
         ctx.logger.info(f"Error embedding chunked text: {e}")
     
     await ctx.emit({
-        'type': 'embed.complete',
+        'topic': 'embed.complete',
         'data': {'message': 'embedding completed'}
     })
     return

--- a/examples/rag_example/steps/index.step.py
+++ b/examples/rag_example/steps/index.step.py
@@ -21,7 +21,7 @@ async def handler(req, ctx):
         ctx.logger.info(f"Error indexing embedded text: {e}")
     
     await ctx.emit({
-        'type': 'index.complete',
+        'topic': 'index.complete',
         'data': {'message': 'indexing completed'}
     })
     return

--- a/examples/rag_example/steps/parse.step.py
+++ b/examples/rag_example/steps/parse.step.py
@@ -12,7 +12,9 @@ config = {
 }
 
 async def handler(req, ctx):
-    input_url = req.body.url
+    input_url = req.body['url']
+
+    ctx.logger.info("Received URL: {}".format(input_url))
     script_path = pathlib.Path().parent / "src" / "parse.py"
     
     try:
@@ -22,7 +24,7 @@ async def handler(req, ctx):
         ctx.logger.info(f"Error parsing website text: {e}")
     
     await ctx.emit({
-        'type': 'parse.complete',
+        'topic': 'parse.complete',
         'data': {'message': 'Parsing completed'}
     })
     

--- a/examples/rag_example/steps/rag_api.step.py
+++ b/examples/rag_example/steps/rag_api.step.py
@@ -18,8 +18,8 @@ config = {
     }
 
 async def handler(req, ctx):
-    query = req.body.query
-    
+    query = req.body['query']
+    ctx.logger.info("Received query: {}".format(query))
     try:
         result = rag_reponse(query)
         message = "RAG response was provided to the user query : {}".format(query)
@@ -28,7 +28,7 @@ async def handler(req, ctx):
         ctx.logger.info("Error responding to user query")
     
     await ctx.emit({
-        'type':'rag.completed',
+        'topic':'rag.completed',
         'data':{'message':'rag response provided'}
         })
     


### PR DESCRIPTION
- Introduced a new motia-workbench configuration file for RAG example.
- Updated package.json to use the latest versions of motia, @types/react, and typescript.
- Modified step handlers to emit events with 'topic' instead of 'type'.
- Added a flowchart diagram for the RAG process in Mermaid format.