### PR TITLE
chore: udpate example to point to the new repository

### DIFF
--- a/examples/motia-docker/Dockerfile
+++ b/examples/motia-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 motiadev/motia-docker:latest
+FROM --platform=linux/amd64 motiadev/motia:latest
 
 # Install Dependencies
 COPY package*.json ./


### PR DESCRIPTION
## What?

- Update the motia-docker example to point to the new repo name